### PR TITLE
Feat/open task on note transfer

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1176,6 +1176,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
     function postReply($vars, &$errors, $alert = true) {
         global $thisstaff, $cfg;
 
+        $wasClosed = $this->isClosed();
 
         if (!$vars['poster'] && $thisstaff)
             $vars['poster'] = $thisstaff;
@@ -1229,6 +1230,10 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
                     'threadentry' => $response,
                     'assignee' => $assignee,
                     ));
+
+        if ($wasClosed) {
+            $this->reopen();
+        }
 
         $this->lastrespondent = $response->staff;
         $this->save();

--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1047,6 +1047,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
         else
             $this->dept_id = $dept->getId();
 
+        $this->reopen(); 
         $this->unassign();
         if ($errors || !$this->save(true))
             return false;

--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1212,7 +1212,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
             $this->setStatus($vars['task:status']);
 
         /*
-        // TODO: add auto claim setting for tasks.
+        // TODO: add auto claim setting for tasks
         // Claim on response bypasses the department assignment restrictions
         if ($thisstaff
             && $this->isOpen()


### PR DESCRIPTION
Cambios realizados:

Al transferir una tarea a otra dependencia, esta se abre automáticamente y se eliminan los asignados previos, si los hubiera.

Si una tarea cerrada recibe una nota pública, se reabre automáticamente.